### PR TITLE
end list with closing bracket

### DIFF
--- a/lib/pretty_dio_logger.dart
+++ b/lib/pretty_dio_logger.dart
@@ -144,7 +144,7 @@ class PrettyDioLogger extends Interceptor {
       else if (response.data is List) {
         logPrint('║${_indent()}[');
         _printList(response.data);
-        logPrint('║${_indent()}[');
+        logPrint('║${_indent()}]');
       } else
         _printBlock(response.data.toString());
     }


### PR DESCRIPTION
Currently a List is logged as:
```
[
  "some",
  "list"
[
```

instead of:
```
[
  "some",
  "list"
]
```