### PR TITLE
Mark `logPrint` as `final`

### DIFF
--- a/lib/pretty_dio_logger.dart
+++ b/lib/pretty_dio_logger.dart
@@ -36,7 +36,7 @@ class PrettyDioLogger extends Interceptor {
   /// Log printer; defaults logPrint log to console.
   /// In flutter, you'd better use debugPrint.
   /// you can also write log in a file.
-  void Function(Object object) logPrint;
+  final void Function(Object object) logPrint;
 
   PrettyDioLogger(
       {this.request = true,


### PR DESCRIPTION
Faced an issue where I had `override`n the `set`ter instead of the `get`ter which led to logging `print(..)` calls even when I didn't want to do that. Realised that I was even able to access the `set`ter in first place because this field isn't `final`.

I couldn't find a reason why it needs to be non-`final` so this PR marks it as `final`.

![image](https://user-images.githubusercontent.com/8232573/157738760-f7bce297-f9c4-49a9-aaf2-a2246b219174.png)

