### PR TITLE
Added Uint8List printing

### DIFF
--- a/lib/pretty_dio_logger.dart
+++ b/lib/pretty_dio_logger.dart
@@ -35,7 +35,7 @@ class PrettyDioLogger extends Interceptor {
   final int maxWidth;
 
   /// Size in which the Uint8List will be splitted
-  static const int chunkSize = 15;
+  static const int chunkSize = 20;
 
   /// Log printer; defaults logPrint log to console.
   /// In flutter, you'd better use debugPrint.


### PR DESCRIPTION
## Description

As mentioned in **[Compacting ResponseType.bytes ? #25](https://github.com/Milad-Akarie/pretty_dio_logger/issues/25)**

When I receive an **Uint8List**, PrettyDioLogger prints each element of the list on a single line, which in my opinion for a Uint8List is not really useful since you'll usually get about 10k lines being printed, and the app will slow down until that stops.

Example of what I mean:
<img width="238" alt="Screenshot 2022-06-21 at 09 46 38" src="https://user-images.githubusercontent.com/18635739/174745039-a9f7d334-5672-483d-940d-9b9dac0c7ea3.png">

With this PR I just wanted to compact the response a little bit, `chunkSize` was set to 20 after some testing.

<img width="542" alt="Screenshot 2022-06-21 at 09 50 11" src="https://user-images.githubusercontent.com/18635739/174745775-dfbe30e0-342e-488c-912e-3df81a1d67d3.png">

---
Also fixed the List printing `[` both at the start, and at the end of the list, instead of `]`


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
