### PR TITLE
Allow for redacting the request and response without modifying either in the dio chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ dio.interceptors.add(PrettyDioLogger());
         maxWidth: 90));
 ```
 
+### Redaction from logs
+
+If there is something that needs to be redacted from the logs extend the `PrettyDioLogger` class and add one of the following snippets:
+
+#### Request
+```dart
+@override
+RequestOptions redactRequest(RequestOptions redactedOptions) {
+   // redaction logic
+
+   return redactedOptions
+}
+```
+
+#### Response
+```dart
+@override
+Response redactResponse(Response redactedResponse) {
+   // redaction logic
+
+   return redactedResponse;
+}
+```
+
 ## How it looks like
 
 ### VS Code

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pretty_dio_logger
 description: Pretty Dio logger is a Dio interceptor that logs network calls in a pretty, easy to read format.
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/Milad-Akarie/pretty_dio_logger
 
 environment:


### PR DESCRIPTION
This came out of a need to redact sensitive information such as auth tokens from being logged. It updates the readme showing how to use, if desired.