### PR TITLE
fix key not shown for multiline value (#7)

### DIFF
--- a/lib/pretty_dio_logger.dart
+++ b/lib/pretty_dio_logger.dart
@@ -236,8 +236,9 @@ class PrettyDioLogger extends Interceptor {
         if (msg.length + indent.length > linWidth) {
           final lines = (msg.length / linWidth).ceil();
           for (var i = 0; i < lines; ++i) {
+            final multilineKey = i == 0 ? "$key:" : "";
             logPrint(
-                '║${_indent(tabs)} ${msg.substring(i * linWidth, math.min<int>(i * linWidth + linWidth, msg.length))}');
+                '║${_indent(tabs)} $multilineKey ${msg.substring(i * linWidth, math.min<int>(i * linWidth + linWidth, msg.length))}');
           }
         } else {
           logPrint('║${_indent(tabs)} $key: $msg${!isLast ? ',' : ''}');


### PR DESCRIPTION
When the log line is too long and being split into multi lines, json key is missing.

**Before:**
I/flutter (15859): ║                {
I/flutter (15859): ║                     "a857d6766e9990dac87ec75e7459f638c86d5b4da452d02579116e9db705f874"
I/flutter (15859): ║                     title: "sample title",

**After:**
I/flutter (18271): ║                {
I/flutter (18271): ║                     id: "a857d6766e9990dac87ec75e7459f638c86d5b4da452d02579116e9db705f874"
I/flutter (18271): ║                     title: "sample title",