### PR TITLE
fix: prevent duplicate request body logging in PrettyDioLogger

### DIFF
--- a/lib/src/pretty_dio_logger.dart
+++ b/lib/src/pretty_dio_logger.dart
@@ -104,8 +104,9 @@ class PrettyDioLogger extends Interceptor {
     if (requestBody && options.method != 'GET') {
       final dynamic data = options.data;
       if (data != null) {
-        if (data is Map) _printMapAsTable(options.data as Map?, header: 'Body');
-        if (data is FormData) {
+        if (data is Map) {
+          _printMapAsTable(options.data as Map?, header: 'Body');
+        } else if (data is FormData) {
           final formDataMap = <String, dynamic>{}
             ..addEntries(data.fields)
             ..addEntries(data.files);


### PR DESCRIPTION
fix(logger): prevent duplicate request body logging for Map data

When requestBody is enabled, Map request data was printed twice: once using _printMapAsTable and again using _printBlock. This happened because the conditions were separate `if` statements.

Changed the second condition to `else if` to ensure the body is logged only once.